### PR TITLE
Do not disable JTAG and SWJ

### DIFF
--- a/Src/stm32f1xx_hal_msp.c
+++ b/Src/stm32f1xx_hal_msp.c
@@ -72,10 +72,6 @@ void HAL_MspInit(void)
   /* SysTick_IRQn interrupt configuration */
   HAL_NVIC_SetPriority(SysTick_IRQn, 0, 0);
 
-    /**DISABLE: JTAG-DP Disabled and SW-DP Disabled 
-    */
-  __HAL_AFIO_REMAP_SWJ_DISABLE();
-
   /* USER CODE BEGIN MspInit 1 */
 
   /* USER CODE END MspInit 1 */


### PR DESCRIPTION
This allows reprograming the sonde withought connecting the reset pin, which makes the wiring for programming simpler.