### PR TITLE
Bidirectional comunication between GPS and the CPU UART

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -148,8 +148,7 @@ int main(void)
   MX_SPI2_Init();
   MX_USART1_UART_Init();
   /* USER CODE BEGIN 2 */
-	char data[100], payload[50];
-	uint8_t buffer[100];
+	char payload[50];
 		
 		//The red LED indecates that the device is on
 		HAL_GPIO_WritePin(GPIOB, LED_red_Pin, GPIO_PIN_RESET);
@@ -200,18 +199,25 @@ int main(void)
 
   /* USER CODE END WHILE */
 		//The flashing red LED showes that the device is ready to generate a clock signal
-		HAL_GPIO_WritePin(GPIOB, LED_red_Pin, GPIO_PIN_SET);
-		HAL_Delay(500);
-		HAL_GPIO_WritePin(GPIOB, LED_red_Pin, GPIO_PIN_RESET);
-		HAL_Delay(500);
-		
-		/*
-		strcpy(data, "Test message\x0d\x0a");
-		HAL_UART_Transmit(&huart3,(uint8_t*) data, strlen(data), HAL_MAX_DELAY);*/
-		
-		//Debuging: Receives data from the GPS-IC and sends it to the terminal connected to UART3 (can be decoded by u-center)
-		HAL_UART_Receive(&huart1, buffer, 70, HAL_MAX_DELAY);
-		HAL_UART_Transmit(&huart3, buffer, 70, HAL_MAX_DELAY);
+		if ((HAL_GetTick() % (HAL_GetTickFreq() * 1000)) > (HAL_GetTickFreq() * 1000 / 2)) {
+			HAL_GPIO_WritePin(GPIOB, LED_red_Pin, GPIO_PIN_SET);
+		} else {
+			HAL_GPIO_WritePin(GPIOB, LED_red_Pin, GPIO_PIN_RESET);
+		}
+
+		// Copy data from huart1 to uart3
+		if (__HAL_UART_GET_FLAG(&huart1, UART_FLAG_RXNE)) {
+			uint8_t d = (uint8_t)(huart1.Instance->DR & (uint8_t)0x00FF);
+			while (!__HAL_UART_GET_FLAG(&huart3, UART_FLAG_TXE)) {}
+			huart3.Instance->DR = d;
+		}
+
+		// Copy data from huart3 to uart1
+		if (__HAL_UART_GET_FLAG(&huart3, UART_FLAG_RXNE)) {
+			uint8_t d = (uint8_t)(huart3.Instance->DR & (uint8_t)0x00FF);
+			while (!__HAL_UART_GET_FLAG(&huart1, UART_FLAG_TXE)) {}
+			huart1.Instance->DR = d;
+		}
   /* USER CODE BEGIN 3 */
 
   }


### PR DESCRIPTION
Create transparent bridge for GPS UART. This allows ad-hoc experimenting with the GPS settings.

Also the original implementation caused occasional NMEA message corruptions due to UART buffer overflow during re-transmission of the data to the host.

The code is pretty low-level. I was not able to achieve any usable results using either interrupts or DMA and the code was actually much more complicated.